### PR TITLE
fix pagination in crud forms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix batching in crud forms [fRiSi]
 
 
 0.8.1 (2015-01-22)

--- a/src/plone/z3cform/crud/crud.py
+++ b/src/plone/z3cform/crud/crud.py
@@ -199,7 +199,7 @@ class EditForm(form.Form):
     label = _(u"Edit")
     template = viewpagetemplatefile.ViewPageTemplateFile('crud-table.pt')
 
-    #exposes the edit sub form for your own derivatives
+    # exposes the edit sub form for your own derivatives
     editsubform_factory = EditSubForm
 
     @property
@@ -225,7 +225,7 @@ class EditForm(form.Form):
         items = self.context.get_items()
         batch_size = self.context.batch_size or sys.maxint
         page = int(self.request.get('%spage' % self.prefix, 0))
-        return Batch.fromPagenumber(items, batch_size, page+1)
+        return Batch.fromPagenumber(items, batch_size, page)
 
     def render_batch_navigation(self):
         bv = CrudBatchView(self.context, self.request)


### PR DESCRIPTION
w/o this fix on plone4.3.18, clicking on the (2) link in the pagination, takes users
to (3). and after leaving the first page, there is no way to navigate
back.

not sure if this is a problem in more recent plone versions. but as 
0.8.x is shipped with plone 4.3.x i start with a pr here.