### PR TITLE
Travis: test on Python 3.8 as well.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: python
-sudo: false
 matrix:
     include:
         - python: "2.7"
         - python: "3.6"
         - python: "3.7"
-          dist: xenial
+        - python: "3.8"
 install:
     - pip install -r https://raw.githubusercontent.com/plone/buildout.coredev/5.2/requirements.txt
     - buildout
 script:
     - bin/test -v1
-notifications:
-    email: false


### PR DESCRIPTION
Then the check-python-versions script is happy.
Cleaned up the Travis config.