### PR TITLE
Fix ++widget++ traversal to `z3c.form.widget.MultiWidget`

### DIFF
--- a/news/22.bugfix
+++ b/news/22.bugfix
@@ -1,0 +1,2 @@
+Fix traversal to `z3c.form.widget.MultiWidget` widgets.
+[petschki]

--- a/src/plone/z3cform/traversal.py
+++ b/src/plone/z3cform/traversal.py
@@ -82,6 +82,9 @@ class FormWidgetTraversal(object):
                                 if w.name == full_name]
                     if len(filtered) == 1:
                         target = filtered[0]
+                        # we have to pop "widgets" from parts here
+                        # this is since z3c.form.widget.MultiWidget >= 4.x
+                        parts.remove("widgets")
                     else:
                         raise TraversalError("'" + part + "' not valid index")
             elif hasattr(target, 'widgets'):  # Either base form, or subform


### PR DESCRIPTION
since `z3c.form >= 4.x` the "subwidget" names got prefixed again with `widget`

this fixes traversal views (eg `@@getSource`) for `zope.schema.Object` fields with `z3c.form.widget.MultiWidget` widgets -> `collective.z3cform.datagridfield`