### PR TITLE
Fix Jenkins tests.

### DIFF
--- a/src/plone/z3cform/crud/README.txt
+++ b/src/plone/z3cform/crud/README.txt
@@ -505,8 +505,7 @@ the correct set of subforms can be processed::
   <BLANKLINE>
   ...
   <form action="http://nohost/context?crud-edit.form.page=1"
-            method="post">
-  ...
+            method="post"...
 
 Let's change Thomas' age on the second page:
 


### PR DESCRIPTION
When running only the plone.z3form tests, the test matched the outcome:

```
<form action="http://nohost/context?crud-edit.form.page=1" method="post">
```

The same is true on the Jenkins PR jobs, which are run in parallel threads. But in Jenkins core jobs, the output is this:

```
<form action="http://nohost/context?crud-edit.form.page=1" method="post" >
```

So after "post" there is an extra space.

There are a few more changes, probably due to `zpretty` having been run somewhere:

```
>                 <span class="header-select" title="">select</span>
---
<                 <span title="" class="header-select" >select</span>
```

It is strange that the parallel jobs pass, but the core jobs fail. This also means it use useless to run PR jobs for this change.